### PR TITLE
Replaced Tax and Discount items with ValueBreakdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This extension was designed to support anti-corruption intiatives around the wor
 
 ## Design
 
-This extension has been designed to allow publishers to link either Accounts Payable data or Bank Statement data into the existing OCDS contract, but in addition to provide detailed reporting on every element that is usually reported in a single invoice, for instance, the extension includes the ability to record taxes, discounts and line item fees. This granular design is critical for being able to compare the price of different items and the cost of each.
+This extension has been designed to allow publishers to link either Accounts Payable data or Bank Statement data into the existing OCDS contract, but in addition to provide detailed reporting on every element that is usually reported in a single invoice, for instance, the extension includes the ability to record taxes, discounts and line item fees. This granular design is critical for being able to compare the price of different items and the cost of each. This extension uses the proposed [`ValueBreakdown`](https://github.com/open-contracting/standard/issues/1070) extension, with an added rate field.
 
 ## Deployment
 

--- a/release-schema.json
+++ b/release-schema.json
@@ -126,9 +126,9 @@
         }
       }
     },
-    "Tax": {
-      "title": "Tax Details",
-      "description": "A breakdown of a single tax applied.",
+    "ValueBreakdown": {
+      "title": "Value Breakdown",
+      "description": "Information on a single value of importance, including net, gross, taxes or discounts applied.",
       "type": "object",
       "minProperties": 1,
       "required": [
@@ -136,14 +136,14 @@
       ],
       "properties": {
         "id": {
-          "title": "Tax Identifier",
-          "description": "A local identifier for this tax array item.",
+          "title": "Value Identifier",
+          "description": "A locally unique identifier for this Value Breakdown. Used to track changes to this value breakdown and to [merge](https://standard.open-contracting.org/latest/en/schema/merging/#merging) multiple releases to create a record.",
           "minLength": 1,
           "type": "string"
         },
-        "name": {
-          "title": "Name of Tax Applied",
-          "description": "A name or short description of the tax applied.",
+        "description": {
+          "title": "Value Breakdown Description",
+          "description": "A short description of the amount, including any reasoning where necessary.",
           "minLength": 1,
           "type": [
             "string",
@@ -151,16 +151,16 @@
           ]
         },
         "rate": {
-          "title": "Tax Rate",
-          "description": "The tax rate given as a decimal.",
+          "title": "Rate Applied",
+          "description": "In the case of a proportional tax or discount, this displays the rate given as a decimal.",
           "type": [
             "number",
             "null"
           ]
         },
         "value": {
-          "title": "Taxed Amount",
-          "description": "The total amount resulting from the tax applied.",
+          "title": "Value Breakdown Amount",
+          "description": "The amount covered in this value breakdown.",
           "$ref": "#/definitions/Value"
         }
       }
@@ -186,36 +186,6 @@
           "description": "The name of the person who authorized this transaction",
           "minLength": 1,
           "type": "string"
-        }
-      }
-    },
-    "Discount": {
-      "title": "Discount",
-      "description": "Details of a discount applied, including a short description, the rate and the value discounted.",
-      "minProperties": 1,
-      "type": "object",
-      "properties": {
-        "description": {
-          "title": "Discount Description",
-          "description": "A short description or name describing the discount applied.",
-          "minLength": 1,
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "rate": {
-          "title": "Discount Rate",
-          "description": "The rate of the discount applied given as a decimal.",
-          "type": [
-            "number",
-            "null"
-          ]
-        },
-        "value": {
-          "title": "Discount value",
-          "description": "The value discounted that this applied discount removes.",
-          "$ref": "#/definitions/Value"
         }
       }
     },
@@ -261,19 +231,14 @@
           "$ref": "#/definitions/Value",
           "description": "The total value of this line item."
         },
-        "discount": {
-          "title": "Discount",
-          "description": "Details of any discount that was applied.",
-          "$ref": "#/definitions/Discount"
-        },
-        "taxes": {
-          "title": "Line Item Taxes",
-          "description": "Taxes applied to this line item.",
+        "valueBreakdown": {
+          "title": "Line Item Value Breakdown",
+          "description": "The breakdown of the value for this line item, including any taxes or discounts applied.",
+          "type": "array",
           "uniqueItems": true,
           "minItems": 1,
-          "type": "array",
           "items": {
-            "$ref": "#/definitions/Tax"
+            "$ref": "#/definitions/ValueBreakdown"
           }
         }
       }
@@ -373,6 +338,16 @@
           "$ref": "#/definitions/Value",
           "description": "The total value covered in this transaction."
         },
+        "valueBreakdown": {
+          "title": "Value Breakdown",
+          "description": "A breakdown of the net and gross value, including details of any tax or discount applied. A discount is indicated by a negative amount.",
+          "type": "array",
+          "uniqueItems": true,
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/ValueBreakdown"
+          }
+        },
         "payer": {
           "title": "Payer",
           "description": "A reference for the organization from which the funds in this transaction originate.",
@@ -401,16 +376,6 @@
           "title": "Payee",
           "description": "An organization reference for the organization which receives the funds in this transaction.",
           "$ref": "#/definitions/OrganizationReference"
-        },
-        "taxes": {
-          "title": "Transaction Taxes",
-          "description": "A detailed breakdown of taxes applied to this transaction.",
-          "uniqueItems": true,
-          "minItems": 1,
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Tax"
-          }
         },
         "budgetCode": {
           "title": "Budget Code",


### PR DESCRIPTION
Using the proposed [`ValueBreakdown`](https://github.com/open-contracting/standard/issues/1070) extension