### PR TITLE
Added `CodeBreakdown` class 

### DIFF
--- a/release-schema.json
+++ b/release-schema.json
@@ -92,6 +92,32 @@
         }
       }
     },
+    "CodeBreakdown": {
+      "title": "Code Breakdown",
+      "description": "An ID and description of a code scheme, that might not have a publicly available schema or be used across different publishers.",
+      "type": "object",
+      "minProperties": 1,
+      "required": [
+        "id"
+      ],
+      "properties": {
+        "id": {
+          "title": "Code Breakdown ID",
+          "description": "The identifier to represent this breakdown.",
+          "minLength": 1,
+          "type": "string"
+        },
+        "description": {
+          "title": "Code Breakdown Description.",
+          "description": "A textual description or title for the given code.",
+          "minLength": 1,
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
     "Transaction": {
       "minProperties": 1,
       "properties": {
@@ -190,12 +216,12 @@
         "budgetCode": {
           "title": "Budget Code",
           "description": "Reference code for the budget of this transaction.",
-          "$ref": "#/definitions/Classification"
+          "$ref": "#/definitions/CodeBreakdown"
         },
         "accountCode": {
           "title": "Account Code",
           "description": "Code linking the payment to the Accounts Payable code.",
-          "$ref": "#/definitions/Classification"
+          "$ref": "#/definitions/CodeBreakdown"
         },
         "classification": {
           "title": "Transaction Classification",


### PR DESCRIPTION
For account and budget codes that may not use a shared schema.